### PR TITLE
Fix mysql deprecation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ relis_app/config/database.php
 /nbproject/
 .idea/*
 
+ci_dev.php
+
 ## Sublime Text cache files
 *.tmlanguage.cache
 *.tmPreferences.cache

--- a/relis_app/controllers/Manager.php
+++ b/relis_app/controllers/Manager.php
@@ -2227,16 +2227,35 @@ class Manager extends CI_Controller {
 	
 	}
 	
+	/**
+	 * Endpoint, to remove the picture associated with a project.
+	 *
+	 * Revision: Due to deprecation of mysql engine within in php. The engine
+	 *           to be used is mysqli, so the calls are changed in a way to use
+	 *           mysqli backend.
+	 * 
+	 * @param  [type] $ref_table  [description]
+	 * @param  [type] $table_name [description]
+	 * @param  [type] $table_id   [description]
+	 * @param  [type] $field      [description]
+	 * @param  [type] $element_id [description]
+	 * @return [type]             [description]
+	 */
 	public function remove_picture($ref_table,$table_name,$table_id,$field,$element_id){
-		$table_name=mysql_real_escape_string($table_name);
-		$table_id=mysql_real_escape_string($table_id);
-		$field=mysql_real_escape_string($field);
-		$element_id=mysql_real_escape_string($element_id);
+		$table_name = $this->manage_mdl->query_escape_str($table_name);
+		$table_id = $this->manage_mdl->query_escape_str($this->db, $table_id);
+		$field = $this->manage_mdl->query_escape_str($this->db, $field);
+		$element_id = $this->manage_mdl->query_escape($this->db, $element_id);
 		
-		$sql = "UPDATE $table_name SET $field = NULL WHERE $table_id ='".$element_id."'";
+		/**
+		 *  made usage of hints regarding coding convetions from codeigniter
+		 *  @see https://www.codeigniter.com/userguide3/general/styleguide.html coding conventions
+		 *  @var string
+		 */
+		$sql = "UPDATE ${table_name} SET ${field}=NULL WHERE ${table_id}=${element_id}";
 		
 	
-		$res=$this->db->query($sql);
+		$res = $this->db->query($sql);
 		
 		if($res){
 			set_top_msg(lng_min("Success - picture removed"));
@@ -2246,7 +2265,7 @@ class Manager extends CI_Controller {
 		}
 		
 	
-			redirect ( 'manager/display_element/' .$ref_table.'/'.$element_id  );
+		redirect ( 'manager/display_element/' .$ref_table.'/'.$element_id  );
 		
 	}
 	

--- a/relis_app/controllers/Op.php
+++ b/relis_app/controllers/Op.php
@@ -26,8 +26,7 @@ class Op extends CI_Controller {
 
 	function __construct()
 	{
-		parent::__construct();
-					
+		parent::__construct();			
 	}
 	
 	/*
@@ -37,7 +36,8 @@ class Op extends CI_Controller {
 	 * 			$val : valeur de recherche si une recherche a été faite sur la table en cours
 	 * 			$page: la page affiché : ulilisé dans la navigation
 	 */
-	public function entity_list($operation_name,$val = "_", $page = 0 ,$dynamic_table=1){
+	public function entity_list($operation_name,$val = "_", $page = 0 ,$dynamic_table=1)
+	{
 		$project_published=project_published();
 		//print_test($project_published);
 		$op=check_operation($operation_name,'List');
@@ -100,14 +100,11 @@ class Op extends CI_Controller {
 		$data=$this->DBConnection_mdl->get_list_mdl($ref_table_config,$val,$page,$rec_per_page);
 		
 	
-	//	print_test($data);
+		//	print_test($data);
 	
 		/*
 		 * récupération des correspondances des clés externes pour l'affichage  suivant la structure de la table
 		 */
-	
-		
-		
 		$dropoboxes=array();
 		foreach ($ref_table_config['operations'][$ref_table_operation]['fields'] as $k_field => $v) {
 			if(!empty($ref_table_config['fields'][$k_field])){
@@ -253,7 +250,7 @@ class Op extends CI_Controller {
 			
 			}
 		}
-	//print_test($link_field_list);
+		//print_test($link_field_list);
 		$i=1;
 		$list_to_display=array();
 		
@@ -371,7 +368,7 @@ class Op extends CI_Controller {
 		}
 	
 	
-	 $data ['list']=$list_to_display;
+	 	$data ['list']=$list_to_display;
 	 
 	 
 		/*
@@ -412,7 +409,7 @@ class Op extends CI_Controller {
 		
 		
 		
-	//	
+		//	
 		if(!empty($ref_table_config['operations'][$ref_table_operation]['top_links']))
 		$data ['top_buttons']=$this->create_top_buttons($ref_table_config['operations'][$ref_table_operation]['top_links']);
 		/*
@@ -662,7 +659,7 @@ class Op extends CI_Controller {
 			//print_test($ref_table_config['report']);
 			$table_id=$ref_table_config['table_id'];
 	
-	//	exit;
+			//	exit;
 			/*
 			 * Appel du model pour récupérer la liste à aficher dans la Base de donnés
 			 */
@@ -889,7 +886,7 @@ class Op extends CI_Controller {
 			}
 	
 	
-	//	print_test($dropoboxes);
+			//	print_test($dropoboxes);
 		
 			/*
 			 * Préparation de la liste à afficher sur base du contenu et  stucture de la table
@@ -1062,10 +1059,10 @@ class Op extends CI_Controller {
 		//print_test($T_result);	
 			
 			//Clean graph
-	//exit;
-	$result=array();
-	$Tzresult=array();
-	//print_test($graph_config);
+			//exit;
+			$result=array();
+			$Tzresult=array();
+			//print_test($graph_config);
 			foreach ($graph_config as $key => $value) {
 				
 				$value['link']=!empty($value['multi_value'])?False:True;
@@ -1188,37 +1185,39 @@ class Op extends CI_Controller {
 	}
 	
 	
-//fonction pour afficher un graphique à partir de la liste- specialisé pour la classifcation
-public function entity_list_graph($operation_name,$val = "_",$page = 0,$graph='all'){
-	$dynamic_table=1;//permet de recuperer toute la liste pas de filtre
-	
-	//récupertaion de la configuration correspondant à l'opération
-	$op=check_operation($operation_name,'List');	
-	$ref_table=$op['tab_ref'];
-	$ref_table_operation=$op['operation_id'];
-	
-	/*
-	* Vérification si il y a une condition de recherche pour redidiger la page 
-	* et appliquer la condition de recherche
-	* Utilisable pour les tableux nob dynamique
-	*/
-	$val = urldecode ( urldecode ( $val ) );
-	$filter = array ();
-	if (isset ( $_POST ['search_all'] )) {
-		$filter = $this->input->post ();
-		unset ( $filter ['search_all'] );
-		$val = "_";
-		if (isset ( $filter ['valeur'] ) and ! empty ( $filter ['valeur'] )) {
-			$val = $filter ['valeur'];
-			$val = urlencode ( urlencode ( $val ) );
-		}
-	
-		/*
-		 * mis à jours de l'url en ajoutant la valeur recherché dans le lien puis rechargement de l'url
-		*/
-		$url = "op/entity_list/" . $operation_name ."/". $val ."/0/".$graph;
-		redirect ( $url );
-	}
+	//fonction pour afficher un graphique à partir de la liste- specialisé pour la classifcation
+
+	public function entity_list_graph($operation_name,$val = "_",$page = 0,$graph='all'){
+			$dynamic_table=1;//permet de recuperer toute la liste pas de filtre
+			
+			//récupertaion de la configuration correspondant à l'opération
+			$op=check_operation($operation_name,'List');	
+			$ref_table=$op['tab_ref'];
+			$ref_table_operation=$op['operation_id'];
+			
+			/*
+			* Vérification si il y a une condition de recherche pour redidiger la page 
+			* et appliquer la condition de recherche
+			* Utilisable pour les tableux nob dynamique
+			*/
+			$val = urldecode ( urldecode ( $val ) );
+			$filter = array ();
+			if (isset ( $_POST ['search_all'] )) 
+			{
+				$filter = $this->input->post ();
+				unset ( $filter ['search_all'] );
+				$val = "_";
+				if (isset ( $filter ['valeur'] ) and ! empty ( $filter ['valeur'] )) {
+					$val = $filter ['valeur'];
+					$val = urlencode ( urlencode ( $val ) );
+				}
+			
+				/*
+				 * mis à jours de l'url en ajoutant la valeur recherché dans le lien puis rechargement de l'url
+				*/
+				$url = "op/entity_list/" . $operation_name ."/". $val ."/0/".$graph;
+				redirect ( $url );
+			}
 	
 	/*
 	* Récupération de la configuration(structure) de la table à afficher
@@ -3694,13 +3693,30 @@ public function entity_list_graph($operation_name,$val = "_",$page = 0,$graph='a
 		
 	}
 	
-	public function remove_picture($ref_table,$table_name,$table_id,$field,$element_id){
-		$table_name=mysql_real_escape_string($table_name);
-		$table_id=mysql_real_escape_string($table_id);
-		$field=mysql_real_escape_string($field);
-		$element_id=mysql_real_escape_string($element_id);
+	/**
+	 * Function, used to manage user's picture within general section.
+	 *
+	 * @todo potentially insecure function, as the permissions are not checked
+	 *       (as far as I can see), and so everyone can delete anybodys picture.
+	 *
+	 * Revision: Changed the usage of mysql_real_escape_string function
+	 * 					 to use a more generic one provided by Codeigniter.
+	 * 					 
+	 * @param  string $ref_table  [description]
+	 * @param  string $table_name [description]
+	 * @param  string $table_id   [description]
+	 * @param  string $field      [description]
+	 * @param  string $element_id [description]
+	 * @return [type]             [description]
+	 */
+	public function remove_picture($ref_table,$table_name,$table_id,$field,$element_id)
+	{
+		$table_name = $this->manage_mdl->escape_str($table_name, 'default');
+		$table_id = $this->manage_mdl->escape_str($table_id, 'default');
+		$field = $this->manage_mdl->escape_str($field, 'default');
+		$element_id = $this->manage_mdl->escape($element_id, 'default');
 		
-		$sql = "UPDATE $table_name SET $field = NULL WHERE $table_id ='".$element_id."'";
+		$sql = "UPDATE $table_name SET $field = NULL WHERE $table_id = ".$element_id;
 		
 		$res =	$this->manage_mdl->run_query($sql,False,'default');
 		
@@ -3717,9 +3733,12 @@ public function entity_list_graph($operation_name,$val = "_",$page = 0,$graph='a
 		
 	}
 	
-	
-	
-	
+	/**
+	 * [new_assignment_screen description]
+	 * @param  [type] $paper_id [description]
+	 * @param  string $redirect [description]
+	 * @return [type]           [description]
+	 */
 	public function new_assignment_screen($paper_id,$redirect="paper_screen"){
 	
 		if(!empty($paper_id) AND $redirect=='paper_screen'){
@@ -3733,6 +3752,12 @@ public function entity_list_graph($operation_name,$val = "_",$page = 0,$graph='a
 		$this->add_element('assignment_screen',$data);
 	}
 	
+	/**
+	 * [create_top_buttons description]
+	 * @param  [type]  $top_links       [description]
+	 * @param  integer $current_element [description]
+	 * @return [type]                   [description]
+	 */
 	private function create_top_buttons($top_links,$current_element=0){
 		$project_published=project_published();
 		//print_test($top_links);

--- a/relis_app/controllers/Op.php
+++ b/relis_app/controllers/Op.php
@@ -3711,10 +3711,10 @@ class Op extends CI_Controller {
 	 */
 	public function remove_picture($ref_table,$table_name,$table_id,$field,$element_id)
 	{
-		$table_name = $this->manage_mdl->escape_str($table_name, 'default');
-		$table_id = $this->manage_mdl->escape_str($table_id, 'default');
-		$field = $this->manage_mdl->escape_str($field, 'default');
-		$element_id = $this->manage_mdl->escape($element_id, 'default');
+		$table_name = $this->manage_mdl->query_escape_str($table_name, 'default');
+		$table_id = $this->manage_mdl->query_escape_str($table_id, 'default');
+		$field = $this->manage_mdl->query_escape_str($field, 'default');
+		$element_id = $this->manage_mdl->query_escape($element_id, 'default');
 		
 		$sql = "UPDATE $table_name SET $field = NULL WHERE $table_id = ".$element_id;
 		

--- a/relis_app/helpers/bm_helper.php
+++ b/relis_app/helpers/bm_helper.php
@@ -543,6 +543,37 @@ function set_log($log_type,$log_event,$log_publish=1,$log_user_id=0,$log_poste_i
 	//print_test($log);
 	$ci->DBConnection_mdl->save_reference_mdl($log);
 }
+
+/**
+ * Returns the database name to be used specified by using an identifier.
+ * In case of 'current' provided (the default), the database associated with
+ * the user's current project is returned.
+ *
+ * The value returned can be used to load a database using the Codeigniter
+ * framework function (e.g. $this->load->database(get_targetdb(), TRUE)).
+ *  
+ * @param  string $target_db The identifier to specify which db name to be 
+ *                           returned, or 'current' by default.
+ * @return string            The db name as string.
+ *
+ * @author Daniel Hofstetter daniel.hofstetter@sbg.ac.at
+ */
+function get_targetdb($target_db = 'current')
+{
+		return ($target_db === 'current') ? project_db() : $target_db;
+}
+
+/**
+ * Helper to return/determine the db associated with the project.
+ * The "active" project is determined by inspection of the user's
+ * session.
+ *
+ * If no db is found (e.g. currently not beeing in any project)
+ * then 'default' gets returned (the value can later be used to 
+ * load a specific database for further operations).
+ * 
+ * @return string the db associated with the project.
+ */
 function project_db() {
 	
 	$ci = get_instance ();
@@ -552,17 +583,26 @@ function project_db() {
 	return 'default';
 }
 
-function active_user_name() {
-
-	$ci = get_instance ();
+/**
+ * Helper to retrieve the username for the currently logged in user.
+ * @return string the user's username, or 'user_unknown'
+ */
+function active_user_name() 
+{
+	$ci = get_instance();
 	if($ci->session->userdata ( 'user_username' ))
 		return $ci->session->userdata ( 'user_username' );
 		else
 			return 'user_unknown';
 }
+/**
+ * Retrieve the project id 
+ * @return [type] [description]
+ */
 function active_project_id() {
 
 	$ci = get_instance ();
+	//TODO: Probably an error to be fixed
 	if($ci->session->userdata ( 'user_id' ))
 		return $ci->session->userdata ( 'project_id' );
 		else

--- a/relis_app/models/Manage_mdl.php
+++ b/relis_app/models/Manage_mdl.php
@@ -316,15 +316,75 @@ class Manage_mdl extends CI_Model
 			return $result;
 		}
 		
+		/**
+		 * A wrapper that simply executes the 
+		 * 			db->escape("...")
+		 * function for multi database environments (Loading is performed
+		 * the same way as done within `run_query` function below).
+		 *
+		 * HINT: Probably obtaining the "normal" database, $this->db
+		 * would be enough anyway, as all databases are using the same
+		 * driver (so escaping would be done anyway in the expected way).
+		 * 
+		 * @author Daniel Hofstetter daniel.hofstetter@sbg.ac.at
+		 * 
+		 * @param  string $value     the value to be escaped as string.
+		 * @param  string $target_db the target database named by a string, 
+		 * 													 or 'current' default. 
+		 * @return string            the escaped value as string.
+		 */
+		function query_escape($value, $target_db = 'current')
+		{
+				return $this->load_database($target_db)->escape($value);
+		}
+		/**
+		 * A wrapper that simply executes the 
+		 * 			db->escape_str("...")
+		 * function for multi database environments (Loading is performed
+		 * the same way as done within `run_query` function below).
+		 *
+		 * HINT: Probably obtaining the "normal" database, $this->db
+		 * would be enough anyway, as all databases are using the same
+		 * driver (so escaping would be done anyway in the expected way).
+		 * 
+		 * @author Daniel Hofstetter daniel.hofstetter@sbg.ac.at
+		 * 
+		 * @param  string $value     the value to be escaped as string.
+		 * @param  string $target_db the target database named by a string, 
+		 * 													 or 'current' default. 
+		 * @return string            the escaped value as string.
+		 */
+		function query_escape_str($value, $target_db = 'current')
+		{
+				return $this->load_database($target_db)->escape_str($value);
+		}
 		
+		/**
+		 * Load the database specified by the identifier ('current' by default, to
+		 * use the currents project db).
+		 * The target_db parameter is translated automatically by using the
+		 * `get_targetdb` helper function.
+		 * 
+		 * @author Daniel Hofstetter daniel.hofstetter@sbg.ac.at
+		 * 
+		 * @param  string $target_db An identifier to specify which db to load.
+		 * @return object|CI_DB_mysql_driver the Database object, FALSE on failure. 
+		 */
+		private function load_database($target_db = 'current')
+		{
+				return $this->load->database(get_targetdb($target_db), TRUE);
+		}
 		
+		/**
+		 * [run_query description]
+		 * @param  [type]  $sql          [description]
+		 * @param  boolean $result_table [description]
+		 * @param  string  $target_db    [description]
+		 * @return [type]                [description]
+		 */
 		function run_query($sql,$result_table=False,$target_db='current'){
-	
-			$target_db=($target_db=='current')?project_db():$target_db;
 			
-			$this->db2 = $this->load->database($target_db, TRUE);
-			
-			
+			$this->db2 = $this->load_database($target_db);
 			
 			if ( !($resu = $this->db2->simple_query($sql)))
 			{


### PR DESCRIPTION
To be ready for using the recent php versions >= 7.0, we need changes in the mysql backend.

## Installation routine

Just replaced the use of __mysql__ backend functions with their appropriate opposite of the __mysqli__ backend. I just did this for index2.php in the install folder. Their are multiple files looking very similar and I just used that file for my installation.

## ReLiS App

I changed the remove_picture endpoints within __Op__ and __Manager__ Controllers, to use new functions within the __Manage_mdl__ Model. There a db object gets obtained from codeigniter. This object provides the database specific escape routines. This change is solid against db Backend changes.

