### PR TITLE
Feature 38

### DIFF
--- a/relis_app/controllers/Op.php
+++ b/relis_app/controllers/Op.php
@@ -1731,7 +1731,7 @@ public function entity_list_graph($operation_name,$val = "_",$page = 0,$graph='a
 	
 	
 	//public function add_element_child($operation_name,$child_field,$ref_table_parent,$parent_id, $data = "",$operation="new",$display_type="normal") {
-	public function add_element_child($operation_name,$parent_id, $data = "",$operation="new",$display_type="normal") {
+	public function add_element_child($operation_name,$parent_id, $data = array(),$operation="new",$display_type="normal") {
 		if((! is_array ($data )) AND $data=='_')
 			$data=array();
 			

--- a/relis_app/helpers/bm_helper.php
+++ b/relis_app/helpers/bm_helper.php
@@ -881,7 +881,7 @@ function user_project($project_id , $user=0,$user_role=""){
 		if($user==0){
 			$user=$ci->session->userdata('user_id');
 		}
-		$sql="select project_id from projects where project_creator=$user AND $use='$project_id' AND project_active=1 ";
+		$sql="select project_id from projects where project_creator=$user AND project_active=1 ";
 	
 		$user_projects = $ci->db->query($sql)->num_rows();
 	


### PR DESCRIPTION
There was a query mistake in _**is_project_creator**_ function (path: relis_app/helpers/bm_helper.php), due to which the "add a reviewer" button was not visible to the **project manager** while there was access to perform the action of a button by directly visiting the URL.

The issue was solved by fixing the query.