### PR TITLE
Screening phases bug fix

### DIFF
--- a/relis_app/models/Screening_dataAccess.php
+++ b/relis_app/models/Screening_dataAccess.php
@@ -296,7 +296,12 @@ class Screening_dataAccess extends CI_Model
             $this->db_current->where('screen_phase_id', $phase_id);
             $query = $this->db_current->get();
             $row = $query->row();  
-            $config_type = $row->config_type;
+            if (empty($row)) {
+                $config_type = 'Default';
+            } else {
+                $row = $query->row();  
+                $config_type = $row->config_type;
+            }
         } else $config_type = 'Default';
         return $config_type;
     }


### PR DESCRIPTION
Fixed screening phase bug by adding a default value for "config_type" for phases that were created before merging pr#159 and don't have a corresponding screen phase config.