### PR TITLE
feat: Resolution of bug Values of some categories are altered to the …

### DIFF
--- a/relis_app/models/DBConnection_mdl.php
+++ b/relis_app/models/DBConnection_mdl.php
@@ -512,7 +512,8 @@ class DBConnection_mdl extends CI_Model
 				}
 				if ($i == 0) {
 
-					if (isset($value['input_type']) and $value['input_type'] == 'date' and empty($val)) {
+					if ((isset($value['input_type']) and $value['input_type'] == 'date' and empty($val)) or 
+						(isset($value['field_type']) and ($value['field_type'] == 'int' or $value['field_type'] == 'number') and empty($val))) {
 						$param .= "NULL";
 					} else {
 						$param .= "'" . mysqli_real_escape_string($this->db3->conn_id, $val ?? '') . "'";
@@ -521,7 +522,8 @@ class DBConnection_mdl extends CI_Model
 
 
 				} else {
-					if (isset($value['input_type']) and $value['input_type'] == 'date' and empty($val)) {
+					if ((isset($value['input_type']) and $value['input_type'] == 'date' and empty($val)) or 
+						(isset($value['field_type']) and ($value['field_type'] == 'int' or $value['field_type'] == 'number') and empty($val))) {
 						$param .= ", " . "NULL";
 					} else {
 						$param .= ",'" . mysqli_real_escape_string($this->db3->conn_id, $val ?? '') . "'";

--- a/relis_app/models/DBConnection_mdl.php
+++ b/relis_app/models/DBConnection_mdl.php
@@ -504,32 +504,16 @@ class DBConnection_mdl extends CI_Model
 
 			$value = $table_config['fields'][$key];
 			if ($v_field['field_state'] != 'drill_down' and $v_field['field_state'] != 'disabled' and !((isset($value['multi-select']) and isset($value['multi-select']) == 'Yes'))) {
-				//print_test($key);
 				if (!empty($content[$key])) {
 					$val = $content[$key];
 				} else {
 					$val = NULL;
 				}
+				$sql_value = $this->get_sql_value($value, $val, $this->db3->conn_id);
 				if ($i == 0) {
-
-					if ((isset($value['input_type']) and $value['input_type'] == 'date' and empty($val)) or 
-						(isset($value['field_type']) and ($value['field_type'] == 'int' or $value['field_type'] == 'number') and empty($val))) {
-						$param .= "NULL";
-					} else {
-						$param .= "'" . mysqli_real_escape_string($this->db3->conn_id, $val ?? '') . "'";
-					}
-
-
-
+					$param .= $sql_value;
 				} else {
-					if ((isset($value['input_type']) and $value['input_type'] == 'date' and empty($val)) or 
-						(isset($value['field_type']) and ($value['field_type'] == 'int' or $value['field_type'] == 'number') and empty($val))) {
-						$param .= ", " . "NULL";
-					} else {
-						$param .= ",'" . mysqli_real_escape_string($this->db3->conn_id, $val ?? '') . "'";
-
-					}
-
+					$param .= ", " . $sql_value;
 				}
 				$i = 1;
 			}
@@ -770,4 +754,23 @@ class DBConnection_mdl extends CI_Model
 		return $result;
 
 	}
+
+    /**
+     * Helper function to generate the correct SQL value for a field.
+     * This refactoring was done to eliminate duplicated logic for handling
+     * NULL values and escaping, improving maintainability and readability.
+     *
+     * If the field is a date or an int/number and the value is empty, returns SQL NULL.
+     * Otherwise, returns the value properly escaped for SQL.
+     */
+    private function get_sql_value($value, $val, $db_conn) {
+        if (
+            (isset($value['input_type']) && $value['input_type'] == 'date' && empty($val)) ||
+            (isset($value['field_type']) && in_array($value['field_type'], ['int', 'number']) && empty($val))
+        ) {
+            return "NULL";
+        } else {
+            return "'" . mysqli_real_escape_string($db_conn, $val ?? '') . "'";
+        }
+    }
 }


### PR DESCRIPTION
**Fix: Empty integer fields saved as 0 instead of NULL**
**Problem Description**
When creating or editing classifications in ReLiS, empty integer fields (such as "Number of citations") were being saved as 0 in the database instead of NULL. This caused issues when editing classifications - fields that were intentionally left empty would show 0 instead of remaining empty.
**Root Cause**
The form processing logic in relis_app/models/DBConnection_mdl.php was only checking for empty date fields to send as NULL to stored procedures, but was not handling empty int or number fields properly. Empty integer fields were being sent as empty strings ('') which MariaDB/MySQL stored procedures automatically convert to 0.
**Solution**
Modified the form processing logic to check for empty integer fields and send them as NULL instead of empty strings.
**Files Changed**
relis_app/models/DBConnection_mdl.php - Modified form processing logic in save_reference_mdl() function
**Testing**
✅ Create a new classification with empty "Number of citations" field
✅ Save the classification - field should store NULL in database
✅ Edit the classification - field should remain empty instead of showing 0
✅ Verify that non-empty integer fields still work correctly
✅ Verify that other field types (text, date, etc.) are not affected

**Screenshots**
<img width="1138" height="720" alt="Screenshot 2025-07-16 at 10 18 35 AM" src="https://github.com/user-attachments/assets/3057639c-1174-471b-bf6a-fb5d8511dcb4" />
<img width="1129" height="731" alt="Screenshot 2025-07-16 at 10 18 45 AM" src="https://github.com/user-attachments/assets/2c9772b2-f2bb-4cf9-b59d-f315bf1a7810" />
