### PR TITLE
Fix #152: handle bug on classification categories

### DIFF
--- a/relis_app/controllers/test/Unit_test.php
+++ b/relis_app/controllers/test/Unit_test.php
@@ -45,6 +45,7 @@ class Unit_test extends CI_Controller
     private $relisManagerUnitTest;
     private $inclusion_mode_conflictUnitTest;
     private $customScreeningPhaseConfigTest;
+    private $managerLibUnitTest;
 
     function __construct()
     {
@@ -75,6 +76,7 @@ class Unit_test extends CI_Controller
         $this->load->helper('tests/op_ut');
         $this->load->helper('tests/inclusion_mode_conflict_ut');
         $this->load->library('unit_test');
+        $this->load->helper('tests/manager_lib_ut');
 
         $this->unit->use_strict(TRUE);
         $this->unit->set_test_items(array('test_controller', 'test_action', 'test_name', 'test_aspect', 'res_value', 'test_value', 'result')); //à voir
@@ -98,6 +100,7 @@ class Unit_test extends CI_Controller
         $this->apiQueryUnitTest = new ApiQueryUnitTest();
         $this->opUnitTest = new OpUnitTest();
         $this->inclusion_mode_conflictUnitTest = new inclusion_mode_conflictUnitTest();
+        $this->managerLibUnitTest = new ManagerLibUnitTest();
     }
 
     public function relis_unit_test($result = "html_report")
@@ -124,6 +127,7 @@ class Unit_test extends CI_Controller
         $this->apiQueryUnitTest->run_tests();
         $this->opUnitTest->run_tests();
         $this->inclusion_mode_conflictUnitTest->run_tests();
+        $this->managerLibUnitTest->run_tests();
 
 
         // Record the end time of the tests

--- a/relis_app/libraries/Manager_lib.php
+++ b/relis_app/libraries/Manager_lib.php
@@ -27,6 +27,40 @@ class Manager_lib
 		$this->CI =& get_instance();
 	}
 
+	/**
+ 		* Fix152: Extract ENUM values from a column when no ref_table exists.
+ 		* Used to support `DynamicList ... depends_on X` where X is declared as a `List` (ENUM).
+ 		* 
+ 		* @param string $column_name The name of the column to inspect
+ 		* @return array List of ENUM values, or empty array if not found / not an ENUM
+ 	*/
+	private function get_enum_values_from_classification($column_name)
+	{
+    	$this->CI->db3 = $this->CI->load->database(project_db(), TRUE);
+    
+    	$sql = "SHOW COLUMNS FROM classification WHERE Field = '" . $this->CI->db3->escape_str($column_name) . "'";
+    	$query = $this->CI->db3->query($sql);
+    
+    	if (!$query) {
+        	return array();
+    	}
+    
+    	$row = $query->row_array();
+    	if (empty($row) || empty($row['Type'])) {
+        	return array();
+    	}
+    
+    	if (preg_match("/^enum\\((.+)\\)$/i", $row['Type'], $matches)) {
+        	preg_match_all("/'([^']*)'/", $matches[1], $values);
+        	return $values[1];
+    	}
+    
+    	return array();
+	}
+    
+    
+
+
 	/*
 		responsible for retrieving reference select values based on a provided configuration. 
 		It supports fetching values from multiple levels of reference tables and applies optional filters.
@@ -35,10 +69,35 @@ class Manager_lib
 	function get_reference_select_values($config, $start_with_empty = True, $get_leaf = False, $multiselect = False, $filter = array())
 	{
 		$conf = explode(";", $config);
-		//	print_test($conf);
-		$ref_table = $conf[0];
-		$fields = $conf[1];
-		$ref_table_config = get_table_configuration($ref_table);
+    
+    	// FIX 152 : handle bare reference names from DSL Forge DependentDynamicCategory
+    	if (count($conf) < 2 || empty($conf[1])) {
+        	$bare_name = $conf[0];
+        	$ref_table = 'ref_' . $bare_name;
+        	$fields    = 'ref_value';
+        
+        $ci = get_instance();
+        if (!$ci->db->table_exists($ref_table)) {
+            $enum_values = $this->get_enum_values_from_classification($bare_name);
+            if (!empty($enum_values)) {
+                $result = array();
+                if ($start_with_empty) {
+                    $result[''] = "Select...";
+                }
+                foreach ($enum_values as $value) {
+                    $result[$value] = $value;
+                }
+                return $result;
+            }
+            log_message('error', "cannot resolve '$bare_name': no ref table, no ENUM column");
+            return array('' => "(Cannot load: '$bare_name')");
+        }
+		} else {
+        	$ref_table = $conf[0];
+        	$fields    = $conf[1];
+    	}
+    
+  		$ref_table_config = get_table_configuration($ref_table);
 		//for_array
 
 		if ($get_leaf) {

--- a/relis_app/views/frm_reference_modal.php
+++ b/relis_app/views/frm_reference_modal.php
@@ -32,7 +32,7 @@
                       <div class="ln_solid"></div>
                       <div class="form-group">
                         <div class="col-md-9 col-sm-9 col-xs-12 col-md-offset-3">
-                        <a href="#" data-dismiss="modal"><button type="button" class="btn btn-primary">close</button></a>
+                        <a href="#" data-dismiss="modal"><button type="button" class="btn btn-primary">Close</button></a>
                
                        <button class="btn btn-success" id="submit_but">Submit</button>
                           

--- a/relis_app/views/general/frm_entity_body.php
+++ b/relis_app/views/general/frm_entity_body.php
@@ -66,7 +66,7 @@ foreach ($table_config['operations'][$current_operation]['fields'] as $key => $v
 	if (!empty($v_field['field_title'])) {
 		$value['field_title'] = $v_field['field_title'];
 	}
-
+	
 	$value['field_title'] = lng($value['field_title']);
 
 	if ($v_field['field_state'] == 'drill_down') {

--- a/relis_app/views/general/frm_entity_modal.php
+++ b/relis_app/views/general/frm_entity_modal.php
@@ -33,7 +33,7 @@
                         <div class="col-md-9 col-sm-9 col-xs-12 col-md-offset-3">
                        
                        <button class="btn btn-success" id="submit_but">Submit</button>
-                        <a href="#" data-dismiss="modal"><button type="button" class="btn btn-primary">close</button></a>
+                        <a href="#" data-dismiss="modal"><button type="button" class="btn btn-primary">Close</button></a>
                   
                         </div>
                       </div>

--- a/relis_app/views/general/frm_reference_modal.php
+++ b/relis_app/views/general/frm_reference_modal.php
@@ -31,7 +31,7 @@
                       <div class="ln_solid"></div>
                       <div class="form-group">
                         <div class="col-md-9 col-sm-9 col-xs-12 col-md-offset-3">
-                        <a href="#" data-dismiss="modal"><button type="button" class="btn btn-primary">close</button></a>
+                        <a href="#" data-dismiss="modal"><button type="button" class="btn btn-primary">Close</button></a>
                
                        <button class="btn btn-success" id="submit_but">Submit</button>
                           


### PR DESCRIPTION
## Fixes #152

### Problem
`DynamicList ... depends_on X` would crash with `Error : Page "X" not found!` 
when clicking +Add on the parent category, both at the root level and inside 
sub-categories.

### Root cause
The DSL Forge generator emits `'input_select_values' => 'X'` (bare name) for 
`DependentDynamicCategory` fields. However, `Manager_lib::get_reference_select_values()` 
expects the format `'table;column'` (e.g. `'ref_X;ref_value'`).

When `explode(";", "X")` returns `["X"]` (no second element):
- `$conf[1]` raises a PHP warning
- `get_table_configuration("X")` cannot find any entity with this name
- The code falls into the "Page not found" branch and redirects

### Investigation
Traced the call chain via debug_backtrace from `Entity_configuration_lib.php`:
- `Element.php::add_element_child()` 
- → `Manager_lib::get_reference_select_values()` 
- → `get_table_configuration()` (fails with bare name)

Comparing with the pre-c5a74d0 codebase (July 2023 refactoring), the 
transformation `'X'` → `'ref_X;ref_value'` was likely handled in the original 
`Install.php` which was split into multiple controllers (`Project.php`, 
`Data_extraction.php`, etc.) during the refactoring.

### Fix
Two changes in `Manager_lib.php`:

1. **Detect bare reference names** at the beginning of `get_reference_select_values()` 
   and resolve them to the expected `ref_X;ref_value` format.

2. **Fallback to ENUM values** when no reference table exists for the bare name 
   (case where the parent is a `List`/ENUM instead of a `DynamicList`). New private 
   method `get_enum_values_from_classification()` reads ENUM values from the column 
   definition via `SHOW COLUMNS`.

### Tested scenarios

- `DynamicList model depends_on brand` at root level
- `DynamicList level1 depends_on cocoa_level` inside a sub-category drill-down
- Multiple dependents on same source (`level1`, `level2` both `depends_on brand`)
- `depends_on` on a `List` (ENUM) - falls back to reading ENUM values
- Save/Edit/Delete cycle in classification

