### PR TITLE
Fix #152: resolve bare reference name in DependentDynamicCategory

### DIFF
--- a/relis_app/libraries/Manager_lib.php
+++ b/relis_app/libraries/Manager_lib.php
@@ -27,6 +27,37 @@ class Manager_lib
 		$this->CI =& get_instance();
 	}
 
+	/**
+ 		* Fix152: Extract ENUM values from a column when no ref_table exists.
+ 		* Used to support `DynamicList ... depends_on X` where X is declared as a `List` (ENUM).
+ 		* 
+ 		* @param string $column_name The name of the column to inspect
+ 		* @return array List of ENUM values, or empty array if not found / not an ENUM
+ 	*/
+	private function get_enum_values_from_classification($column_name)
+	{
+    	$this->CI->db3 = $this->CI->load->database(project_db(), TRUE);
+    
+    	$sql = "SHOW COLUMNS FROM classification WHERE Field = '" . $this->CI->db3->escape_str($column_name) . "'";
+    	$query = $this->CI->db3->query($sql);
+    
+    	if (!$query) {
+        	return array();
+    	}
+    
+    	$row = $query->row_array();
+    	if (empty($row) || empty($row['Type'])) {
+        	return array();
+    	}
+    
+    	if (preg_match("/^enum\\((.+)\\)$/i", $row['Type'], $matches)) {
+        	preg_match_all("/'([^']*)'/", $matches[1], $values);
+        	return $values[1];
+    	}
+    
+    	return array();
+	}
+	
 	/*
 		responsible for retrieving reference select values based on a provided configuration. 
 		It supports fetching values from multiple levels of reference tables and applies optional filters.
@@ -35,10 +66,35 @@ class Manager_lib
 	function get_reference_select_values($config, $start_with_empty = True, $get_leaf = False, $multiselect = False, $filter = array())
 	{
 		$conf = explode(";", $config);
-		//	print_test($conf);
-		$ref_table = $conf[0];
-		$fields = $conf[1];
-		$ref_table_config = get_table_configuration($ref_table);
+    
+    	// FIX 152 : handle bare reference names from DSL Forge DependentDynamicCategory
+    	if (count($conf) < 2 || empty($conf[1])) {
+        	$bare_name = $conf[0];
+        	$ref_table = 'ref_' . $bare_name;
+        	$fields    = 'ref_value';
+        
+        $ci = get_instance();
+        if (!$ci->db->table_exists($ref_table)) {
+            $enum_values = $this->get_enum_values_from_classification($bare_name);
+            if (!empty($enum_values)) {
+                $result = array();
+                if ($start_with_empty) {
+                    $result[''] = "Select...";
+                }
+                foreach ($enum_values as $value) {
+                    $result[$value] = $value;
+                }
+                return $result;
+            }
+            log_message('error', "cannot resolve '$bare_name': no ref table, no ENUM column");
+            return array('' => "(Cannot load: '$bare_name')");
+        }
+		} else {
+        	$ref_table = $conf[0];
+        	$fields    = $conf[1];
+    	}
+    
+  		$ref_table_config = get_table_configuration($ref_table);
 		//for_array
 
 		if ($get_leaf) {


### PR DESCRIPTION
## Summary

Resolves #152.

## Problem

`Manager_lib::get_reference_select_values()` expected `input_select_values` in the `table;column` format. However, when DSL Forge generates the classification config for a `DependentDynamicCategory` field, it emits a bare reference name (e.g. `cocoa_level`) instead of `ref_cocoa_level;ref_value`. As a result, dropdowns for these fields showed no options.

## Fix

Added a fallback in `get_reference_select_values()`:
- If `input_select_values` is a bare name → build the conventional `ref_<name>` table and `ref_value` field
- If the `ref_<name>` table does not exist (e.g. `depends_on List`) → fall back to extracting ENUM values from the classification config

## Tested scenarios

- `DynamicList` `depends_on` a `DynamicList` (root category + sub-category) → correct dropdown values
- `DynamicList` `depends_on` a `List` (fallback ENUM) → correct dropdown values with a graceful degradation
- Save / Edit / Delete cycle → all work correctly