### PR TITLE
Fix #21: display sub-categories as separate columns

### DIFF
--- a/deployment/db/initial_db.sql
+++ b/deployment/db/initial_db.sql
@@ -550,8 +550,13 @@ articles','ReLiS allows you to manually add references or import a list from CSV
             <h4><b>Dependent Dynamic List</b></h4>\r\n
             <p>This is similar to a <code>Dynamic List</code>, but the values come from another category. This is useful if you want to restrict the possible values, but these values come from another <code>DynamicList</code> category. The format is:</p>\r\n<pre>\r\n<b>DynamicList</b> category_name <b>\"</b>Label to display<b>\" * [</b>n<b>]</b> <b>depends_on</b> dependent_category\r\n</pre>\r\n
             <dl>\r\n<dt><code>category_name</code>, <code>Label to display</code>, <code>*</code>, <code>n</code></dt>\r\n
-                <dd>Same as the <code>Dynamic List</code> category.</dd>\r\n<dt><code>dependent_category</code></dt>\r\n
-                <dd>The <code>category_name</code> of another <code>Dynamic List</code> from which the values are populated.</dd>\r\n</dl>\r\n
+                <dt><code>dependent_category</code></dt>
+                <dd>The <code>category_name</code> of another <code>Dynamic List</code> from which the values are populated.</dd>
+                </dl>
+                <b>Warning:</b> When <code>depends_on</code> targets a <code>Dynamic List</code> parent that has only a single selected value, the filtering behavior is not enforced. 
+                The sub-category dropdown will display all the values defined in the parent dynamic list instead of only the selected one. For guaranteed filtering,
+                 ensure the parent dynamic list has multiple selected values.</p>\r\n
+                
             <h4><b>Sub-categories</b></h4>\r\n
             <p>Any of the above categories can contain sub-categories. A category containing sub-categories is called a super-category. On the data extraction form, adding a value to a super-category will pop-up a secondary form. The format is:</p>\r\n<pre>\r\nSUPER CATEGORY DEFINITION <b>{</b>\r\n  SUB CATEGORY DEFINITION\r\n  SUB CATEGORY DEFINITION\r\n<b>}</b>\r\n</pre>\r\n
             <p>Here, <code>SUPER</code> and <code>SUB CATEGORY DEFINITION</code> are the same as any category type above. All you need is to enclose the sub-categories between curly brackets.\r\n</p>\r\n

--- a/relis_app/controllers/Element.php
+++ b/relis_app/controllers/Element.php
@@ -1281,19 +1281,32 @@ class Element extends CI_Controller
          * @var array $field_list va contenir les champs à afficher
          * @var array $ field_list will contain the fields to display
          */
-        $link_field_list = array();
+$link_field_list = array();
         $field_list = array();
         $field_list_header = array();
         foreach ($ref_table_config['operations'][$ref_table_operation]['fields'] as $k => $v) {
-            //print_test($k);
-            //print_test($v);
             if (!empty($ref_table_config['fields'][$k])) {
-                //$field_det=$ref_table_config['fields'][$k];
                 array_push($field_list, $k);
                 $field_header = !empty($v['field_title']) ? $v['field_title'] : $ref_table_config['fields'][$k]['field_title'];
                 array_push($field_list_header, $field_header);
                 if (!empty($v['link'])) {
                     $link_field_list[$k] = $v;
+                }
+                
+                // FIX #21 : add sub-categories as separate columns
+                $field_config = $ref_table_config['fields'][$k];
+                if (!empty($field_config['category_type']) &&
+                    in_array($field_config['category_type'], ['WithSubCategories', 'WithMultiValues'])) {
+                    $sub_table_config = get_table_configuration($k);
+                    if (!empty($sub_table_config['fields'])) {
+                        foreach ($sub_table_config['fields'] as $sub_key => $sub_field) {
+                            if (!empty($sub_field['category_type']) &&
+                                $sub_field['category_type'] === 'DependentDynamicCategory') {
+                                array_push($field_list, $k . '.' . $sub_key);
+                                array_push($field_list_header, $field_header . '.' . $sub_field['field_title']);
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -1303,7 +1316,30 @@ class Element extends CI_Controller
         foreach ($data['list'] as $key => $value) {
             $element_array = array();
             $element_array['links'] = '';
+            
             foreach ($field_list as $key_field => $v_field) {
+                // FIX #21 : composite key "supercat.subcat" - resolve sub-category values via DBConnection_mdl
+                if (strpos($v_field, '.') !== false) {
+                    list($parent_field, $sub_field_name) = explode('.', $v_field, 2);
+
+                    // Get the intermediate (depends_on) table name from the field configuration
+                    $sub_table_config = get_table_configuration($parent_field);
+                    $sub_field_config = $sub_table_config['fields'][$sub_field_name] ?? null;
+                    $intermediate = $sub_field_config['input_select_values'] ?? null;
+
+                    if (!empty($intermediate)) {
+                        $sub_values = $this->DBConnection_mdl->get_subcategory_resolved_values(
+                            $parent_field,
+                            $sub_field_name,
+                            $intermediate,
+                            $data['list'][$key][$table_id]
+                        );
+                        $element_array[$v_field] = implode(' | ', $sub_values);
+                    } else {
+                        $element_array[$v_field] = "";
+                    }
+                        continue;
+                }
                 if (isset($value[$v_field])) {
                     if (isset($dropoboxes[$v_field][$value[$v_field]])) {
                         $element_array[$v_field] = $dropoboxes[$v_field][$value[$v_field]];
@@ -1537,6 +1573,22 @@ class Element extends CI_Controller
                 array_push($field_list, $k);
                 $field_header = !empty($v['field_title']) ? $v['field_title'] : $ref_table_config['fields'][$k]['field_title'];
                 array_push($field_list_header, $field_header);
+
+                // FIX #21 : add sub-categories as separate columns
+                $field_config = $ref_table_config['fields'][$k];
+                if (!empty($field_config['category_type']) &&
+                    in_array($field_config['category_type'], ['WithSubCategories', 'WithMultiValues'])) {
+                    $sub_table_config = get_table_configuration($k);
+                    if (!empty($sub_table_config['fields'])) {
+                        foreach ($sub_table_config['fields'] as $sub_key => $sub_field) {
+                            if (!empty($sub_field['category_type']) &&
+                                $sub_field['category_type'] === 'DependentDynamicCategory') {
+                                array_push($field_list, $k . '.' . $sub_key);
+                                array_push($field_list_header, $field_header . '.' . $sub_field['field_title']);
+                            }
+                        }
+                    }
+                }
             }
         }
         $i = 1;
@@ -1544,6 +1596,28 @@ class Element extends CI_Controller
         foreach ($data['list'] as $key => $value) {
             $element_array = array();
             foreach ($field_list as $key_field => $v_field) {
+               // FIX #21 : composite key "supercat.subcat" - resolve sub-category values via DBConnection_mdl
+                if (strpos($v_field, '.') !== false) {
+                    list($parent_field, $sub_field_name) = explode('.', $v_field, 2);
+    
+                    // Get the intermediate (depends_on) table name from the field configuration
+                    $sub_table_config = get_table_configuration($parent_field);
+                    $sub_field_config = $sub_table_config['fields'][$sub_field_name] ?? null;
+                    $intermediate = $sub_field_config['input_select_values'] ?? null;
+    
+                    if (!empty($intermediate)) {
+                        $sub_values = $this->DBConnection_mdl->get_subcategory_resolved_values(
+                        $parent_field,
+                        $sub_field_name,
+                        $intermediate,
+                        $data['list'][$key][$table_id]
+                        );
+                        $element_array[$v_field] = implode(' | ', $sub_values);
+                    } else {
+                        $element_array[$v_field] = "";
+                    }
+                    continue;
+                }
                 if (isset($value[$v_field])) {
                     if (isset($dropoboxes[$v_field][$value[$v_field]])) {
                         $element_array[$v_field] = $dropoboxes[$v_field][$value[$v_field]];

--- a/relis_app/controllers/Reporting.php
+++ b/relis_app/controllers/Reporting.php
@@ -161,12 +161,29 @@ class Reporting extends CI_Controller
 		 */
 		$field_list = array();
 		$field_list_header = array();
-		foreach ($ref_table_config['fields'] as $k => $v) {
-			if ($v['on_list'] == 'show') {
-				array_push($field_list, $k);
-				array_push($field_list_header, $v['field_title']);
-			}
-		}
+		$field_list = array();
+        $field_list_header = array();
+        foreach ($ref_table_config['fields'] as $k => $v) {
+            if ($v['on_list'] == 'show') {
+                array_push($field_list, $k);
+                array_push($field_list_header, $v['field_title']);
+
+                // FIX #21 : add sub-categories as separate columns
+                if (!empty($v['category_type']) &&
+                    in_array($v['category_type'], ['WithSubCategories', 'WithMultiValues'])) {
+                    $sub_table_config = get_table_configuration($k);
+                    if (!empty($sub_table_config['fields'])) {
+                        foreach ($sub_table_config['fields'] as $sub_key => $sub_field) {
+                            if (!empty($sub_field['category_type']) &&
+                                $sub_field['category_type'] === 'DependentDynamicCategory') {
+                                array_push($field_list, $k . '.' . $sub_key);
+                                array_push($field_list_header, $v['field_title'] . '.' . $sub_field['field_title']);
+                            }
+                        }
+                    }
+                }
+            }
+        }
 		//prepare paper info 
 		$this->db2 = $this->load->database(project_db(), TRUE);
 
@@ -205,6 +222,29 @@ class Reporting extends CI_Controller
 			$element_array['search_strategy'] = !empty($arrangedPapers[$value['class_paper_id']]) ? $arrangedPapers[$value['class_paper_id']]['search_strategy'] : '';
 			$element_array['reviewers'] = !empty($arrangedPapers[$value['class_paper_id']]) ? $arrangedPapers[$value['class_paper_id']]['reviewers'] : '';
 			foreach ($field_list as $key_field => $v_field) {
+				// FIX #21 : composite key "supercat.subcat" - resolve sub-category values via DBConnection_mdl
+				if (strpos($v_field, '.') !== false) {
+    				list($parent_field, $sub_field_name) = explode('.', $v_field, 2);
+    
+    				// Get the intermediate (depends_on) table name from the field configuration
+    				$sub_table_config = get_table_configuration($parent_field);
+    				$sub_field_config = $sub_table_config['fields'][$sub_field_name] ?? null;
+    				$intermediate = $sub_field_config['input_select_values'] ?? null;
+    
+    				if (!empty($intermediate)) {
+        				$sub_values = $this->DBConnection_mdl->get_subcategory_resolved_values(
+            			$parent_field,
+            			$sub_field_name,
+            			$intermediate,
+            			$data['list'][$key][$table_id]
+        				);
+        				$element_array[$v_field] = implode(' | ', $sub_values);
+    				} else {
+        				$element_array[$v_field] = "";
+    				}
+    					continue;
+				}
+
 				if (isset($value[$v_field])) {
 					if (isset($dropoboxes[$v_field][$value[$v_field]])) {
 						$element_array[$v_field] = $dropoboxes[$v_field][$value[$v_field]];
@@ -767,7 +807,8 @@ class Reporting extends CI_Controller
 		$rsae_classification_form = array_change_key_case($rsae_classification_form, CASE_LOWER);
 
 		foreach ($table_fields as $field_name => &$field_value) {
-			$field_title = strtolower(preg_replace('/[\s\-?]/', '_', $field_value['field_title']));
+			// FIX #21: also convert dots so composite "SuperCat.SubCat" titles match form keys
+			$field_title = strtolower(preg_replace('/[\s\-?.]/', '_', $field_value['field_title']));
 			// Check if the key exists in the array
 			if (!array_key_exists($field_title, $rsae_classification_form)) {
 				unset($table_fields[$field_name]);
@@ -817,11 +858,38 @@ class Reporting extends CI_Controller
 	 */
 	private function python_extract_classification_configuration()
 	{
-		$table_ref = "classification";
+    	$table_ref = "classification";
 
-		$this->db2 = $this->load->database(project_db(), TRUE);
-		$ref_table_config = get_table_config($table_ref);
-		return $ref_table_config['fields'];
+    	$this->db2 = $this->load->database(project_db(), TRUE);
+    	$ref_table_config = get_table_config($table_ref);
+    	$fields = $ref_table_config['fields'];
+
+    	// FIX #21: include DependentDynamicCategory sub-fields so that sub-categories
+    	// appear in the generated Python export files (consistent with the CSV export
+    	// and the RSAE configuration form).
+    	$extended_fields = array();
+    	foreach ($fields as $field_key => $field) {
+        	$extended_fields[$field_key] = $field;
+        	if (!empty($field['category_type']) &&
+            	in_array($field['category_type'], ['WithSubCategories', 'WithMultiValues'])) {
+            	$sub_table_config = get_table_configuration($field_key);
+            	if (!empty($sub_table_config['fields'])) {
+                	foreach ($sub_table_config['fields'] as $sub_key => $sub_field) {
+                    	if (!empty($sub_field['category_type']) &&
+                        	$sub_field['category_type'] === 'DependentDynamicCategory') {
+                        	$composite_key   = $field_key . '.' . $sub_key;
+                        	$composite_title = ($field['field_title'] ?? $field_key)
+                                         . '.' . ($sub_field['field_title'] ?? $sub_key);
+                        	$extended_fields[$composite_key] = array_merge($sub_field, [
+                            	'field_title' => $composite_title
+                        	]);
+                    	}
+                	}
+            	}
+        	}
+    	}
+
+    	return $extended_fields;	
 	}
 
 	/**
@@ -1078,22 +1146,52 @@ class Reporting extends CI_Controller
 
 	public function rsae_export_configurations($rsae_gpl, $data = "", $operation = "new", $display_type = "normal")
 	{
-		$res_install_config = $this->entity_configuration_lib->get_install_config();
-		$fields = $res_install_config['config']['classification']['fields'];
-		// Remove the first 2 elements using array_slice()
-		$fields = array_slice($fields, 2);
-		// Remove the last 3 elements using array_slice() and a negative offset
-		$fields = array_slice($fields, 0, -3);
+    	$res_install_config = $this->entity_configuration_lib->get_install_config();
+    	$fields = $res_install_config['config']['classification']['fields'];
+    	// Remove the first 2 elements using array_slice()
+    	$fields = array_slice($fields, 2);
+    	// Remove the last 3 elements using array_slice() and a negative offset
+    	$fields = array_slice($fields, 0, -3);
 
-		$data = $this->session->userdata('redirect_values');
+    	// FIX #21: include DependentDynamicCategory sub-fields under WithSubCategories /
+    	// WithMultiValues parents (e.g. "Variety.Level 1") so they appear in the
+    	// RSAE configuration form and end up in the exported R/Python files.
+    	$extended_fields = array();
+		foreach ($fields as $field_key => $field) {
+        	$extended_fields[$field_key] = $field;
+        
+        	if (!empty($field['category_type']) &&
+            	in_array($field['category_type'], ['WithSubCategories', 'WithMultiValues'])) {
+            	$sub_table_config = get_table_configuration($field_key);
+            	if (!empty($sub_table_config['fields'])) {
+                	foreach ($sub_table_config['fields'] as $sub_key => $sub_field) {
+                    	if (!empty($sub_field['category_type']) &&
+                        	$sub_field['category_type'] === 'DependentDynamicCategory') {
+                        	$composite_key   = $field_key . '.' . $sub_key;
+                        	$composite_title = ($field['field_title'] ?? $field_key)
+                                         . '.' . ($sub_field['field_title'] ?? $sub_key);
+                        	// Inherit the sub_field properties but override the title
+                        	// to be the composite "SuperCat.SubCat" (same format as in
+                        	// the CSV columns produced by generate_result_export_classification).
+                        	$extended_fields[$composite_key] = array_merge($sub_field, [
+                            	'field_title' => $composite_title
+                        	]);
+                    	}
+                	}
+            	}
+        	}
+    	}
+    	$fields = $extended_fields;
 
-		$data["rsae_gpl"] = $rsae_gpl;
+    	$data = $this->session->userdata('redirect_values');
 
-		$data["category"] = $fields;
+    	$data["rsae_gpl"] = $rsae_gpl;
 
-		$data['page'] = 'relis/rsae_export_configurations';
+    	$data["category"] = $fields;
 
-		$this->load->view('shared/body', $data);
+    	$data['page'] = 'relis/rsae_export_configurations';
+
+    	$this->load->view('shared/body', $data);
 	}
 
 	/**

--- a/relis_app/models/DBConnection_mdl.php
+++ b/relis_app/models/DBConnection_mdl.php
@@ -680,9 +680,51 @@ class DBConnection_mdl extends CI_Model
 
 
     }
+    // FIX #21 : get subcategries to display them 
+   function get_subcategory_resolved_values($parent_table, $sub_field, $intermediate, $element_id)
+    {
+        $this->db2 = $this->load->database(project_db(), TRUE);
+    
+        // FIX #21: $intermediate may be in the form "table;column" 
+        $intermediate_parts = explode(';', $intermediate);
+        $intermediate_table = $intermediate_parts[0];
+    
+        $ref_table = 'ref_' . $intermediate_table;
+        $intermediate_id_col = $intermediate_table . '_id';
+        $intermediate_value_col = $intermediate_table;
+        $parent_key = 'parent_field_id';
+        $active_field = $parent_table . '_active';
+    
+        // Detect which case we are in by checking table existence
+        $intermediate_exists = $this->db2->table_exists($intermediate_table);
+        $ref_exists = $this->db2->table_exists($ref_table);
+    
+        if ($intermediate_exists && $ref_exists) {
+            // Case A: depends_on DynamicList - double join via intermediate table
+            // Example: variety.level1 -> cocoa_level.cocoa_level_id -> ref_cocoa_level.ref_id
+            $sql = "SELECT r.ref_value
+                FROM $parent_table p
+                LEFT JOIN $intermediate_table i ON i.$intermediate_id_col = p.$sub_field
+                LEFT JOIN $ref_table r ON r.ref_id = i.$intermediate_value_col
+                WHERE p.$parent_key = ?
+                  AND p.$active_field = 1";
+        
+            $rows = $this->db2->query($sql, array($element_id))->result_array();
+            return array_column($rows, 'ref_value');
+        }
+    
+        // Case B: depends_on List - no intermediate table, value stored directly in parent
+        // Example: type.level1 contains the value directly (ENUM-style or raw)
+        $sql = "SELECT $sub_field AS value
+            FROM $parent_table p
+            WHERE p.$parent_key = ?
+              AND p.$active_field = 1";
+    
+        $rows = $this->db2->query($sql, array($element_id))->result_array();
+        return array_column($rows, 'value');
+    }
 
-
-
+    
     /*
      * Fonction pour appeler la procédure stockée qui récupère la liste d'éléments suivant les paramètres reçus
      * Input: $ref_table_config: le nom donné à le stucture de la table à récuperer

--- a/relis_app/views/frm_reference_modal.php
+++ b/relis_app/views/frm_reference_modal.php
@@ -32,7 +32,7 @@
                       <div class="ln_solid"></div>
                       <div class="form-group">
                         <div class="col-md-9 col-sm-9 col-xs-12 col-md-offset-3">
-                        <a href="#" data-dismiss="modal"><button type="button" class="btn btn-primary">close</button></a>
+                        <a href="#" data-dismiss="modal"><button type="button" class="btn btn-primary">Close</button></a>
                
                        <button class="btn btn-success" id="submit_but">Submit</button>
                           

--- a/relis_app/views/general/frm_entity_modal.php
+++ b/relis_app/views/general/frm_entity_modal.php
@@ -33,7 +33,7 @@
                         <div class="col-md-9 col-sm-9 col-xs-12 col-md-offset-3">
                        
                        <button class="btn btn-success" id="submit_but">Submit</button>
-                        <a href="#" data-dismiss="modal"><button type="button" class="btn btn-primary">close</button></a>
+                        <a href="#" data-dismiss="modal"><button type="button" class="btn btn-primary">Close</button></a>
                   
                         </div>
                       </div>

--- a/relis_app/views/general/frm_reference_modal.php
+++ b/relis_app/views/general/frm_reference_modal.php
@@ -31,7 +31,7 @@
                       <div class="ln_solid"></div>
                       <div class="form-group">
                         <div class="col-md-9 col-sm-9 col-xs-12 col-md-offset-3">
-                        <a href="#" data-dismiss="modal"><button type="button" class="btn btn-primary">close</button></a>
+                        <a href="#" data-dismiss="modal"><button type="button" class="btn btn-primary">Close</button></a>
                
                        <button class="btn btn-success" id="submit_but">Submit</button>
                           


### PR DESCRIPTION
## Summary

Resolves #21.

Sub-categories (`DependentDynamicCategory`) were absent from the List Classifications table, the CSV export, and the R/Python export files. This PR displays them everywhere as separate columns formatted `SuperCat.SubCat` (e.g. `Variety.Level 1`).

## Changes

### Model layer

- **`models/DBConnection_mdl.php`** — New method `get_subcategory_resolved_values($parent_table, $sub_field, $intermediate, $element_id)` that resolves `DependentDynamicCategory` values through a **double join** via the intermediate table pattern (`variety.level1` → `cocoa_level.cocoa_level_id` → `ref_cocoa_level.ref_id`). Handles both `depends_on DynamicList` (double join) and `depends_on List` (fallback to raw value).

### Controller / display layer

- **`controllers/Element.php`** — Extended `entity_list()` and `entity_list_data()` to detect super-categories (`WithSubCategories`, `WithMultiValues`) and add each `DependentDynamicCategory` sub-field as a separate column, formatted `SuperCat.SubCat`.

### CSV export

- **`controllers/Reporting.php`** — Extended `generate_result_export_classification()` with the same logic so CSV exports include the sub-category columns.

### RSAE R and Python exports

- **`controllers/Reporting.php`** — Extended `rsae_export_configurations()` so the configuration form proposes sub-categories.
- **`controllers/Reporting.php`** — Extended `python_extract_classification_configuration()` so Python export scripts include sub-categories.
- **`controllers/Reporting.php`** — Updated the field-title normalization regex in `python_statistical_analysis_model_factory()` to also convert dots to underscores, matching how PHP converts dots in POST parameter names.

### Documentation

- **`deployment/db/initial_db.sql`** — Added a Warning paragraph in the Data extraction help page about the `depends_on` limitation when the parent has a single selected value.

### Cosmetic

- **`views/frm_reference_modal.php`, `views/general/frm_entity_modal.php`, `views/general/frm_reference_modal.php`** — Cosmetic fix: `close` → `Close` on the modal close button.

## Tested scenarios

- `DynamicList` `variety` with `depends_on cocoa_level (DynamicList)` → correctly resolves and displays sub-category values (`Variety.Level 1: 100%`, `Variety.Level 2: 35%`)
- CSV export contains the new `SuperCat.SubCat` columns with correctly resolved values
- R export configuration form lists sub-categories; generated R config file includes `desc_distr_vector[['Variety.Level.1']]` etc.
- Python export configuration form lists sub-categories; generated Python playground file includes statistical tests for `variety_level_1` and `variety_level_2`
- Soft-deleted rows (`<parent>_active = 0`) are filtered out
- Single-variety paper and multi-variety paper (concatenation with `|`)